### PR TITLE
Preserve Filevine folder structure on download

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,6 @@ filenames that include the document ID for uniqueness.
 - Works with either the US or CA Filevine environment
 - Optional progress bar using `tqdm`
 
+- Preserves the Filevine folder hierarchy under the chosen download directory
+
 All downloaded documents will be placed in the chosen directory.


### PR DESCRIPTION
## Summary
- request folder path data when listing documents
- create subdirectories based on each document's folder path when saving files
- document new folder hierarchy behavior in README

## Testing
- `python3 -m py_compile download_documents.py`